### PR TITLE
Add ability to double/reroll rolls above a specified number

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ to the result.
 or equal to 7 will be rerolled. The target number can be
 changed with `/tn`. For example `.roll/tn6 #` will roll #
 dice, generating a success for each number greater than or
-euqal to 6.
+equal to 6.
 * Doubles generate twice the number of successes. If you
 are rolling double 9's, each 9 in your pool would add two
 successes instead of one. `.roll/db789 #` would roll # dice
@@ -36,6 +36,9 @@ use /no10 in the roll: `.roll/no10 #`.
 `.roll/re56 8` will roll 8 dice, rerolling 5's and 6's.
 These cascade, meaning that if another 5 or 6 is rerolled,
 it will be rerolled as well.
+* `/db#+` and `/re#+` can be used to double/reroll all rolls
+from # to 10. `.roll/db7+` would double the successes of
+7, 8, 9, and 10. This does not override no10.
 
 Text output: D10 bot will reply with the dice you rolled
 and computes the number of successes. Successes are bolded,
@@ -50,4 +53,4 @@ inviting him to a channel you administrate.
 * ~~Better error handling~~ **added somewhat subpar error handling 2016-07-31 let's see if it's enough**
 * ~~More helpful help (really any help feature at all)~~
 * ~~Option to not double 10's~~ **/no10 flag added2016-07-30**
-* Option to have /db7+ mean double 7, 8, 9, and 10
+* ~~Option to have /db7+ mean double 7, 8, 9, and 10~~

--- a/exalted-roller.js
+++ b/exalted-roller.js
@@ -75,7 +75,7 @@ function parseMessage(message) {
 
   // Some variables and shortcuts to use:
   var anyNumber = /^\d+/g;
-  var tenOrSingleDigit = /10|\d/g;
+  var tenOrSingleDigitOptionalPlus = /(10|\d)\+?/g;
 
   // If there's a number of dice at the end of the roll message...
   if (parsed[1].match(anyNumber)) {
@@ -101,18 +101,32 @@ function parseMessage(message) {
         theRoll.target = parseInt(target, 10);
       }
       // set doubles
-      // To-do: add code for double 7+ (doub;les 7,8,9,and 10)
       if (options[i].startsWith('db')) {
-        var double = options[i].match(tenOrSingleDigit)
+        var double = options[i].match(tenOrSingleDigitOptionalPlus)
         double && double.forEach(function (item) {
-          theRoll.doubleSet.add(parseInt(item, 10))
+          if (item.includes("+")) {
+            // db#+ doubles successes on rolls from # to 10
+            // note that this does not override no10
+            for (var j = parseInt(item, 10); j <= 10; j++) {
+              theRoll.doubleSet.add(j)
+            }
+          } else {
+            theRoll.doubleSet.add(parseInt(item, 10))
+          }
         })
       }
       // set rerolls
       if (options[i].startsWith('re')) {
-        var reroll = options[i].match(tenOrSingleDigit)
+        var reroll = options[i].match(tenOrSingleDigitOptionalPlus)
         reroll && reroll.forEach(function (item) {
-          theRoll.rerollSet.add(parseInt(item, 10))
+          if (item.includes("+")) {
+            // re#+ rerolls rolls from # to 10
+            for (var j = parseInt(item, 10); j <= 10; j++) {
+              theRoll.rerollSet.add(j)
+            }
+          } else {
+            theRoll.rerollSet.add(parseInt(item, 10))
+          }
         })
         let set = theRoll.rerollSet
         // Stop infinite cascading reroll


### PR DESCRIPTION
This adds the feature to "have /db7+ mean double 7, 8, 9, and 10". This change also applies to rerolling.

Note that this can be used in tandem with the previous functionality, so that `.roll/re37+ #` will reroll 3, 7, 8, 9, and 10.

Notably, this does not override no10, so `.roll/db7+/no10 #` will only double 7, 8, and 9.